### PR TITLE
Add a string concatenation to _read_body()

### DIFF
--- a/MYMETA.json
+++ b/MYMETA.json
@@ -4,7 +4,7 @@
       "Ilya Rassadin <elcamlost@gmail.com>"
    ],
    "dynamic_config" : 0,
-   "generated_by" : "Module::Build version 0.4214",
+   "generated_by" : "Module::Build version 0.422",
    "license" : [
       "artistic_1"
    ],

--- a/lib/ClickHouse.pm
+++ b/lib/ClickHouse.pm
@@ -221,13 +221,16 @@ sub _read_body {
     my ($self) = @_;
 
     my @response;
+    my $content = '';
     while (1) {
         my $buf;
         my $n = $self->_get_socket()->read_entity_body($buf, 1024);
         die "can't read response: $!" unless defined $n;
         last unless $n;
-        push @response, split (/\n/, $buf);
+        $content .= $buf;
     }
+    push @response, split (/\n/, $content);
+
     return \@response;
 }
 

--- a/lib/ClickHouse.pm
+++ b/lib/ClickHouse.pm
@@ -221,15 +221,23 @@ sub _read_body {
     my ($self) = @_;
 
     my @response;
-    my $content = '';
+    my $remainder = '';
     while (1) {
         my $buf;
-        my $n = $self->_get_socket()->read_entity_body($buf, 1024);
+        my $n = $self->_get_socket()->read_entity_body( $buf, 1024 );
+        $buf       = $remainder . $buf;
+        $remainder = '';
         die "can't read response: $!" unless defined $n;
         last unless $n;
-        $content .= $buf;
+        if ( $buf =~ s!([^\n]+\z)!! ) {
+            $remainder = $1;
+        }
+        push @response, split( /\n/, $buf );
     }
-    push @response, split (/\n/, $content);
+
+    # warn if remainder is not empty (shouldn't happen)
+    # in case that read_entity_body() returns an empty string but $remainder still has content
+    carp "remainder not empty:{$remainder}" if $remainder;
 
     return \@response;
 }


### PR DESCRIPTION
I found that this fixes random breakage of results while selecting
from a database.

Fixes issue #2

String concatenation may not be best solution for large selects because
it builds large variable in memory (propose better solution if available).
