### PR TITLE
Support common selectall_arrayref and selectcol_arrayref use cases

### DIFF
--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -65,6 +65,9 @@
 ^MYMETA\.
 #!end included /Users/camlost/.plenv/versions/5.26.0/lib/perl5/5.26.0/ExtUtils/MANIFEST.SKIP
 
+# Avoid docker file used for development
+docker-compose.yml
+
 .idea
 local
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+---
+db:
+  image: yandex/clickhouse-server
+  ports:
+    - 8123:8123
+    - 9000:9000

--- a/lib/ClickHouse.pm
+++ b/lib/ClickHouse.pm
@@ -183,6 +183,41 @@ sub select_value {
     return $arrayref->[0]->[0];
 }
 
+sub selectall_arrayref {
+    my ($self, $query, $attr) = @_;
+
+    if (ref $attr && ref $attr->{Columns} eq 'HASH') {
+        return $self->_selectall_arrayref_hashref($query, $attr);
+    }
+
+    return $self->select($query);
+}
+
+sub _selectall_arrayref_hashref {
+    my ($self, $query, $attr) = @_;
+
+    my $arrayref = $self->select("$query FORMAT TabSeparatedWithNames");
+    return           unless defined $arrayref && ref $arrayref eq 'ARRAY';
+    return $arrayref unless scalar @{$arrayref};
+
+    my $columns = shift @{$arrayref};
+    foreach my $row (@{$arrayref}) {
+        my %row;
+        @row{ @{$columns} } = @{$row};
+        $row = \%row;
+    }
+
+    return $arrayref;
+}
+
+sub selectcol_arrayref {
+    my ($self, $query) = @_;
+    my $arrayref = $self->select($query);
+
+    return unless defined $arrayref && ref $arrayref eq 'ARRAY';
+    return [ map { $_->[0] } @{$arrayref} ];
+}
+
 sub do {
     my ($self, $query, @rows) = @_;
     return $self->_query(sub {

--- a/t/release-integration.t
+++ b/t/release-integration.t
@@ -1,0 +1,37 @@
+#!perl
+
+use 5.010;
+use strict;
+use warnings;
+
+use Test::More;
+
+unless ( $ENV{RELEASE_TESTING} ) {
+    plan skip_all => "Author tests not required for installation";
+}
+
+BEGIN {
+    use_ok 'ClickHouse' or die;
+}
+
+diag "Testing ClickHouse $ClickHouse::VERSION, Perl $], $^X";
+
+my $db = new_ok 'ClickHouse';
+$db->ping or die 'local instance not running, unable to run tests';
+
+my $query = 'show databases';
+is_deeply $db->selectall_arrayref($query),
+    $db->select($query),
+    'selectall_arrayref() OK';
+
+is_deeply $db->selectall_arrayref($query, { Columns => {} }),
+    [ map { {name => $_->[0]} } @{ $db->select($query) } ],
+    'selectall_arrayref(query, {Columns => {}}) OK';
+
+is_deeply $db->selectcol_arrayref($query),
+    [ map { $_->[0] } @{ $db->select($query) } ],
+    'selectcol_arrayref() OK';
+
+done_testing;
+
+__END__


### PR DESCRIPTION
Hi.

I add a (my) most commonly used methods so I can use it as a drop in replacement for DBD::mysql.

